### PR TITLE
Update rune_PL_wrk.service

### DIFF
--- a/config/usr/lib/systemd/system/rune_PL_wrk.service
+++ b/config/usr/lib/systemd/system/rune_PL_wrk.service
@@ -3,8 +3,9 @@ Description=RuneAudio Playback Worker
 After=network.target
 
 [Service]
+ExecStartPre=-/bin/sleep 15
 ExecStart=/var/www/command/rune_PL_wrk
-TimeoutSec=0
+TimeoutSec=70
 Restart=always
 
 [Install]


### PR DESCRIPTION
This service have no stable running. 
In my case (I have external wifi adapter), arch load rune_PL firstly, and after it's loading wifi drivers.
Thus rune_PL on running get down because wifi is off now.
I guess it is not good solution, but it's working.